### PR TITLE
Fix potential vulnerability in a cloned function

### DIFF
--- a/mm/pagewalk.c
+++ b/mm/pagewalk.c
@@ -118,8 +118,11 @@ static int walk_hugetlb_range(struct vm_area_struct *vma,
 	do {
 		next = hugetlb_entry_end(h, addr, end);
 		pte = huge_pte_offset(walk->mm, addr & hmask);
-		if (pte && walk->hugetlb_entry)
+		if (pte)
 			err = walk->hugetlb_entry(pte, hmask, addr, next, walk);
+		else if (walk->pte_hole)
+			err = walk->pte_hole(addr, next, walk);
+
 		if (err)
 			return err;
 	} while (addr = next, addr != end);


### PR DESCRIPTION
Hi again,

I identified another potential vulnerability in a clone function `walk_hugetlb_range()` in `mm/pagewalk.c` sourced from [torvalds/linux](https://github.com/torvalds/linux). This issue, originally reported in [CVE-2017-16994](https://nvd.nist.gov/vuln/detail/https://github.com/advisories/CVE-2017-16994), was resolved in the repository via this commit https://github.com/torvalds/linux/commit/373c4557d2aa362702c4c2d41288fb1e54990b7c.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you!