### PR TITLE
Fix delay release of struct bcm_op after synchronize_rcu()

### DIFF
--- a/net/can/bcm.c
+++ b/net/can/bcm.c
@@ -774,6 +774,7 @@ static int bcm_delete_rx_op(struct list_head *ops, canid_t can_id, int ifindex)
 						  bcm_rx_handler, op);
 
 			list_del(&op->list);
+			synchronize_rcu();
 			bcm_remove_op(op);
 			return 1; /* done */
 		}
@@ -1470,9 +1471,12 @@ static int bcm_release(struct socket *sock)
 			can_rx_unregister(NULL, op->can_id,
 					  REGMASK(op->can_id),
 					  bcm_rx_handler, op);
-
-		bcm_remove_op(op);
 	}
+
+	synchronize_rcu();
+
+	list_for_each_entry_safe(op, next, &bo->rx_ops, list)
+		bcm_remove_op(op);
 
 	/* remove procfs entry */
 	if (proc_dir && bo->bcm_proc_read)


### PR DESCRIPTION
This PR fixes a potential security vulnerability in `bcm` that was cloned from [torvalds/linux](https://github.com/torvalds/linux) but did not receive the security patch.

Details:

Affected Function: `bcm ` in `net/can/bcm.c`
Original Fix: https://github.com/torvalds/linux/commit/d5f9023fa61ee8b94f37a93f08e94b136cf1e463
What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

References:

- https://github.com/torvalds/linux/commit/d5f9023fa61ee8b94f37a93f08e94b136cf1e463
- https://nvd.nist.gov/vuln/detail/cve-2021-3609

Please review and merge this PR to ensure your repository is protected against this potential vulnerability.