### PR TITLE
Initialize rcv_mss to TCP_MIN_MSS instead of 0

### DIFF
--- a/net/ipv4/tcp.c
+++ b/net/ipv4/tcp.c
@@ -2288,6 +2288,10 @@ int tcp_disconnect(struct sock *sk, int flags)
 	tcp_set_ca_state(sk, TCP_CA_Open);
 	tcp_clear_retrans(tp);
 	inet_csk_delack_init(sk);
+	/* Initialize rcv_mss to TCP_MIN_MSS to avoid division by 0
+	 * issue in __tcp_select_window()
+	 */
+	icsk->icsk_ack.rcv_mss = TCP_MIN_MSS;
 	tcp_init_send_head(sk);
 	memset(&tp->rx_opt, 0, sizeof(tp->rx_opt));
 	__sk_dst_reset(sk);


### PR DESCRIPTION
This PR fixes a security vulnerability in `tcp_disconnect` that was cloned from torvalds/linux but did not receive the security patch.

**Vulnerability Details:**

* **Affected Function**: `tcp_disconnect` in `net/ipv4/tcp.c`
* **Original Fix**: https://github.com/torvalds/linux/commit/499350a5a6e7512d9ed369ed63a4244b6536f4f8

**What this PR does:** This PR applies the same security patch that was applied to the original repository to eliminate the vulnerability in the cloned code.

**References:**

* https://github.com/torvalds/linux/commit/499350a5a6e7512d9ed369ed63a4244b6536f4f8
* https://nvd.nist.gov/vuln/detail/cve-2017-14106

Please review and merge this PR to ensure your repository is protected against this vulnerability.