### PR TITLE
Fox inherit fastopen_req from parent

### DIFF
--- a/net/ipv4/tcp_minisocks.c
+++ b/net/ipv4/tcp_minisocks.c
@@ -490,6 +490,7 @@ struct sock *tcp_create_openreq_child(struct sock *sk, struct request_sock *req,
 			newicsk->icsk_ack.last_seg_size = skb->len - newtp->tcp_header_len;
 		newtp->rx_opt.mss_clamp = req->mss;
 		tcp_ecn_openreq_child(newtp, req);
+		newtp->fastopen_req = NULL;
 		newtp->fastopen_rsk = NULL;
 		newtp->syn_data_acked = 0;
 


### PR DESCRIPTION
This PR fixes a security vulnerability in `tcp_create_openreq_child` that was cloned from `torvalds/linux` but did not receive the security patch.

**Vulnerability Details:**

* **Affected Function**: `tcp_create_openreq_child` in `net/ipv4/tcp_minisocks.c`
* **Original Fix**: https://github.com/torvalds/linux/commit/8b485ce69876c65db12ed390e7f9c0d2a64eff2c

**What this PR does:** This PR applies the same security patch that was applied to the original repository to eliminate the vulnerability in the cloned code.

**References:**

* https://github.com/torvalds/linux/commit/8b485ce69876c65db12ed390e7f9c0d2a64eff2c

Please review and merge this PR to ensure your repository is protected against this vulnerability.