### PR TITLE
Check sk for closed state in dccp_sendmsg()

### DIFF
--- a/net/dccp/proto.c
+++ b/net/dccp/proto.c
@@ -780,6 +780,11 @@ int dccp_sendmsg(struct kiocb *iocb, struct sock *sk, struct msghdr *msg,
 	if (skb == NULL)
 		goto out_release;
 
+	if (sk->sk_state == DCCP_CLOSED) {
+		rc = -ENOTCONN;
+		goto out_discard;
+	}
+	
 	skb_reserve(skb, sk->sk_prot->max_header);
 	rc = memcpy_fromiovec(skb_put(skb, len), msg->msg_iov, len);
 	if (rc != 0)


### PR DESCRIPTION
This PR fixes a potential security vulnerability in `dccp_sendmsg` that was cloned from `torvalds/linux` but did not receive the security patch.

**Vulnerability Details:**

* **Affected Function**: `dccp_sendmsg` in `net/dccp/proto.c`
* **Original Fix**: https://github.com/torvalds/linux/commit/67f93df79aeefc3add4e4b31a752600f834236e2

**What this PR does:** This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

**References:**

* https://github.com/torvalds/linux/commit/67f93df79aeefc3add4e4b31a752600f834236e2
* [CVE-2018-1130](https://nvd.nist.gov/vuln/detail/cve-2018-1130)

Please review and merge this PR to ensure your repository is protected against this vulnerability.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/libos-nuse/net-next-nuse/72)
<!-- Reviewable:end -->
