### PR TITLE
Fix potential vulnerability in cloned code

### DIFF
--- a/net/rds/rdma.c
+++ b/net/rds/rdma.c
@@ -853,6 +853,7 @@ int rds_cmsg_atomic(struct rds_sock *rs, struct rds_message *rm,
 err:
 	if (page)
 		put_page(page);
+	rm->atomic.op_active = 0;
 	kfree(rm->atomic.op_notifier);
 
 	return ret;


### PR DESCRIPTION
This PR fixes a potential security vulnerability in `rds_cmsg_atomic` that was cloned from `torvalds/linux` but did not receive the security patch.

**Vulnerability Details:**

* **Affected Function**: `rds_cmsg_atomic` in `net/rds/rdma.c`
* **Original Fix**: https://github.com/torvalds/linux/commit/7d11f77f84b27cef452cee332f4e469503084737

**What this PR does:** This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

**References:**

* https://github.com/torvalds/linux/commit/7d11f77f84b27cef452cee332f4e469503084737
* [CVE-2018-5333](https://nvd.nist.gov/vuln/detail/cve-2018-5333)

Please review and merge this PR to ensure your repository is protected against this vulnerability.