### PR TITLE
Fix potential vulnerability in cloned code

### DIFF
--- a/sound/usb/mixer.c
+++ b/sound/usb/mixer.c
@@ -1773,7 +1773,7 @@ static int build_audio_procunit(struct mixer_build *state, int unitid,
 				char *name)
 {
 	struct uac_processing_unit_descriptor *desc = raw_desc;
-	int num_ins = desc->bNrInPins;
+	int num_ins;
 	struct usb_mixer_elem_info *cval;
 	struct snd_kcontrol *kctl;
 	int i, err, nameid, type, len;
@@ -1788,7 +1788,13 @@ static int build_audio_procunit(struct mixer_build *state, int unitid,
 		0, NULL, default_value_info
 	};
 
-	if (desc->bLength < 13 || desc->bLength < 13 + num_ins ||
+	if (desc->bLength < 13) {
+		usb_audio_err(state->chip, "invalid %s descriptor (id %d)\n", name, unitid);
+		return -EINVAL;
+	}
+
+	num_ins = desc->bNrInPins;
+	if (desc->bLength < 13 + num_ins ||
 	    desc->bLength < num_ins + uac_processing_unit_bControlSize(desc, state->mixer->protocol)) {
 		usb_audio_err(state->chip, "invalid %s descriptor (id %d)\n", name, unitid);
 		return -EINVAL;


### PR DESCRIPTION
This PR fixes a potential security vulnerability in `build_audio_procunit` that was cloned from `torvalds/linux` but did not receive the security patch.

**Vulnerability Details:**

* **Affected Function**: `build_audio_procunit` in `sound/usb/mixer.c`
* **Original Fix**: https://github.com/torvalds/linux/commit/f4351a199cc120ff9d59e06d02e8657d08e6cc46

**What this PR does:** This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

**References:**

* https://github.com/torvalds/linux/commit/f4351a199cc120ff9d59e06d02e8657d08e6cc46
* [CVE-2019-15927](https://nvd.nist.gov/vuln/detail/CVE-2019-15927)

Please review and merge this PR to ensure your repository is protected against this vulnerability.