### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/net/bridge/netfilter/ebtables.c
+++ b/net/bridge/netfilter/ebtables.c
@@ -2079,13 +2079,22 @@ static int size_entry_mwt(struct ebt_entry *entry, const unsigned char *base,
 	 * offsets are relative to beginning of struct ebt_entry (i.e., 0).
 	 */
 	for (i = 0; i < 4 ; ++i) {
+	for (i = 0; i < 4 ; ++i) {
+		if (offsets[i] >= *total)
 		if (offsets[i] >= *total)
 			return -EINVAL;
+			return -EINVAL;
+		if (i == 0)
 		if (i == 0)
 			continue;
+			continue;
+		if (offsets[i-1] > offsets[i])
 		if (offsets[i-1] > offsets[i])
 			return -EINVAL;
+			return -EINVAL;
 	}
+	}
+
 
 	for (i = 0, j = 1 ; j < 4 ; j++, i++) {
 		struct compat_ebt_entry_mwt *match32;


### PR DESCRIPTION
## Summary
This PR fixes a potential security vulnerability in cloned code that appears to have missed an upstream security patch.

## Details
- **Affected file**: `net/bridge/netfilter/ebtables.c`
- **Upstream fix commit**: https://github.com/torvalds/linux/commit/b71812168571fa55e44cdd0254471331b9c4c4c6
- **Clone similarity score**: 0.997366

## What this PR does
- Applies the upstream security fix logic to the cloned implementation in this repository.

## References
- Upstream patch commit: https://github.com/torvalds/linux/commit/b71812168571fa55e44cdd0254471331b9c4c4c6

Please review and merge this PR to ensure your repository is protected against this potential vulnerability. 
Thank you for your time !
