### PR TITLE
Fix potential vulnerability in cloned code

### DIFF
--- a/drivers/usb/misc/sisusbvga/sisusb.c
+++ b/drivers/usb/misc/sisusbvga/sisusb.c
@@ -3093,6 +3093,13 @@ static int sisusb_probe(struct usb_interface *intf,
 
 	mutex_init(&(sisusb->lock));
 
+	sisusb->sisusb_dev = dev;
+	sisusb->vrambase   = SISUSB_PCI_MEMBASE;
+	sisusb->mmiobase   = SISUSB_PCI_MMIOBASE;
+	sisusb->mmiosize   = SISUSB_PCI_MMIOSIZE;
+	sisusb->ioportbase = SISUSB_PCI_IOPORTBASE;
+	/* Everything else is zero */
+
 	/* Register device */
 	if ((retval = usb_register_dev(intf, &usb_sisusb_class))) {
 		dev_err(&sisusb->sisusb_dev->dev, "Failed to get a minor for device %d\n",
@@ -3101,13 +3108,7 @@ static int sisusb_probe(struct usb_interface *intf,
 		goto error_1;
 	}
 
-	sisusb->sisusb_dev = dev;
-	sisusb->minor      = intf->minor;
-	sisusb->vrambase   = SISUSB_PCI_MEMBASE;
-	sisusb->mmiobase   = SISUSB_PCI_MMIOBASE;
-	sisusb->mmiosize   = SISUSB_PCI_MMIOSIZE;
-	sisusb->ioportbase = SISUSB_PCI_IOPORTBASE;
-	/* Everything else is zero */
+	sisusb->minor = intf->minor;
 
 	/* Allocate buffers */
 	sisusb->ibufsize = SISUSB_IBUF_SIZE;


### PR DESCRIPTION
This PR fixes a potential security vulnerability in `sisusb_probe` that was cloned from `torvalds/linux` but did not receive the security patch.

**Vulnerability Details:**

* **Affected Function**: `sisusb_probe` in `drivers/usb/misc/sisusbvga/sisusb.c`
* **Original Fix**: https://github.com/torvalds/linux/commit/9a5729f68d3a82786aea110b1bfe610be318f80a

**What this PR does:** This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

**References:**

* https://github.com/torvalds/linux/commit/9a5729f68d3a82786aea110b1bfe610be318f80a
* [CVE-2019-15219
](https://nvd.nist.gov/vuln/detail/CVE-2019-15219)

Please review and merge this PR to ensure your repository is protected against this vulnerability.