### PR TITLE
Fix potential vulnerability in cloned code

### DIFF
--- a/drivers/usb/serial/cypress_m8.c
+++ b/drivers/usb/serial/cypress_m8.c
@@ -447,6 +447,11 @@ static int cypress_generic_port_probe(struct usb_serial_port *port)
 	struct usb_serial *serial = port->serial;
 	struct cypress_private *priv;
 
+	if (!port->interrupt_out_urb || !port->interrupt_in_urb) {
+		dev_err(&port->dev, "required endpoint is missing\n");
+		return -ENODEV;
+	}
+
 	priv = kzalloc(sizeof(struct cypress_private), GFP_KERNEL);
 	if (!priv)
 		return -ENOMEM;
@@ -604,13 +609,6 @@ static int cypress_open(struct tty_struct *tty, struct usb_serial_port *port)
 
 	if (tty)
 		cypress_set_termios(tty, port, &priv->tmp_termios);
-
-	/* setup the port and start reading from the device */
-	if (!port->interrupt_in_urb) {
-		dev_err(&port->dev, "%s - interrupt_in_urb is empty!\n",
-			__func__);
-		return -1;
-	}
 
 	usb_fill_int_urb(port->interrupt_in_urb, serial->dev,
 		usb_rcvintpipe(serial->dev, port->interrupt_in_endpointAddress),


### PR DESCRIPTION
This PR fixes a potential security vulnerability in `cypress_generic_port_probe` that was cloned from `torvalds/linux` but did not receive the security patch.

**Vulnerability Details:**

* **Affected Function**: `cypress_generic_port_probe` in `drivers/usb/serial/cypress_m8.c`
* **Original Fix**: https://github.com/torvalds/linux/commit/c55aee1bf0e6b6feec8b2927b43f7a09a6d5f754

**What this PR does:** This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

**References:**

* https://github.com/torvalds/linux/commit/c55aee1bf0e6b6feec8b2927b43f7a09a6d5f754
* [CVE-2016-3137](https://nvd.nist.gov/vuln/detail/cve-2016-3137)

Please review and merge this PR to ensure your repository is protected against this vulnerability.