### PR TITLE
Fix potential vulnerability in a cloned function

### DIFF
--- a/drivers/usb/misc/iowarrior.c
+++ b/drivers/usb/misc/iowarrior.c
@@ -787,6 +787,12 @@ static int iowarrior_probe(struct usb_interface *interface,
 	iface_desc = interface->cur_altsetting;
 	dev->product_id = le16_to_cpu(udev->descriptor.idProduct);
 
+	if (iface_desc->desc.bNumEndpoints < 1) {
+		dev_err(&interface->dev, "Invalid number of endpoints\n");
+		retval = -EINVAL;
+		goto error;
+	}
+
 	/* set up the endpoint information */
 	for (i = 0; i < iface_desc->desc.bNumEndpoints; ++i) {
 		endpoint = &iface_desc->endpoint[i].desc;


### PR DESCRIPTION
Hi again,

I identified another potential vulnerability in a clone function `iowarrior_probe()` in `drivers/usb/misc/iowarrior.c` sourced from [torvalds/linux](https://github.com/torvalds/linux). This issue, originally reported in [CVE-2016-2188](https://nvd.nist.gov/vuln/detail/https://github.com/advisories/CVE-2016-2188), was resolved in the repository via this commit https://github.com/torvalds/linux/commit/4ec0ef3a82125efc36173062a50624550a900ae0.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you!