### PR TITLE
Fix potential vulnerability in a cloned function

### DIFF
--- a/drivers/usb/serial/visor.c
+++ b/drivers/usb/serial/visor.c
@@ -544,6 +544,11 @@ static int treo_attach(struct usb_serial *serial)
 		(serial->num_interrupt_in == 0))
 		return 0;
 
+	if (serial->num_bulk_in < 2 || serial->num_interrupt_in < 2) {
+		dev_err(&serial->interface->dev, "missing endpoints\n");
+		return -ENODEV;
+	}
+
 	/*
 	* It appears that Treos and Kyoceras want to use the
 	* 1st bulk in endpoint to communicate with the 2nd bulk out endpoint,


### PR DESCRIPTION
Hi again,

I identified another potential vulnerability in a clone function in `drivers/usb/serial/visor.c` sourced from [torvalds/linux](https://github.com/torvalds/linux). This issue, originally reported in [CVE-2016-2782](https://nvd.nist.gov/vuln/detail/cve-2016-2782), was resolved in the repository via this commit https://github.com/torvalds/linux/commit/cac9b50b0d75a1d50d6c056ff65c005f3224c8e0.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you!