### PR TITLE
Fix potential vulnerability in a cloned function

### DIFF
--- a/drivers/media/usb/gspca/ov519.c
+++ b/drivers/media/usb/gspca/ov519.c
@@ -3497,6 +3497,11 @@ static void ov511_mode_init_regs(struct sd *sd)
 		return;
 	}
 
+	if (alt->desc.bNumEndpoints < 1) {
+		sd->gspca_dev.usb_err = -ENODEV;
+		return;
+	}
+
 	packet_size = le16_to_cpu(alt->endpoint[0].desc.wMaxPacketSize);
 	reg_w(sd, R51x_FIFO_PSIZE, packet_size >> 5);
 
@@ -3619,6 +3624,11 @@ static void ov518_mode_init_regs(struct sd *sd)
 	if (!alt) {
 		PERR("Couldn't get altsetting\n");
 		sd->gspca_dev.usb_err = -EIO;
+		return;
+	}
+
+	if (alt->desc.bNumEndpoints < 1) {
+		sd->gspca_dev.usb_err = -ENODEV;
 		return;
 	}
 


### PR DESCRIPTION
Hi again,

I identified another potential vulnerability in a clone function in `drivers/media/usb/gspca/ov519.c` sourced from [torvalds/linux](https://github.com/torvalds/linux). This issue, originally reported in [CVE-2020-11608](https://nvd.nist.gov/vuln/detail/cve-2020-11608), was resolved in the repository via this commit https://github.com/torvalds/linux/commit/998912346c0da53a6dbb71fab3a138586b596b30.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you!