### PR TITLE
Fix potential vulnerability in a cloned function

### DIFF
--- a/drivers/net/wireless/ath/ath9k/htc_hst.c
+++ b/drivers/net/wireless/ath/ath9k/htc_hst.c
@@ -171,6 +171,7 @@ static int htc_config_pipe_credits(struct htc_target *target)
 	time_left = wait_for_completion_timeout(&target->cmd_wait, HZ);
 	if (!time_left) {
 		dev_err(target->dev, "HTC credit config timeout\n");
+		kfree_skb(skb);
 		return -ETIMEDOUT;
 	}
 
@@ -206,6 +207,7 @@ static int htc_setup_complete(struct htc_target *target)
 	time_left = wait_for_completion_timeout(&target->cmd_wait, HZ);
 	if (!time_left) {
 		dev_err(target->dev, "HTC start timeout\n");
+		kfree_skb(skb);
 		return -ETIMEDOUT;
 	}
 
@@ -278,6 +280,7 @@ int htc_connect_service(struct htc_target *target,
 	if (!time_left) {
 		dev_err(target->dev, "Service connection timeout for: %d\n",
 			service_connreq->service_id);
+		kfree_skb(skb);
 		return -ETIMEDOUT;
 	}
 


### PR DESCRIPTION
Hi again,

I identified another potential vulnerability in clone functions in `drivers/net/wireless/ath/ath9k/htc_hst.c` sourced from [torvalds/linux](https://github.com/torvalds/linux). This issue, originally reported in [CVE-2019-19073](https://nvd.nist.gov/vuln/detail/cve-2019-19073), was resolved in the repository via this commit https://github.com/torvalds/linux/commit/853acf7caf10b828102d92d05b5c101666a6142b.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you!