### PR TITLE
Fix potential vulnerability in a cloned function

### DIFF
--- a/drivers/media/usb/ttusb-dec/ttusb_dec.c
+++ b/drivers/media/usb/ttusb-dec/ttusb_dec.c
@@ -272,7 +272,7 @@ static int ttusb_dec_send_command(struct ttusb_dec *dec, const u8 command,
 
 	dprintk("%s\n", __func__);
 
-	b = kmalloc(COMMAND_PACKET_SIZE + 4, GFP_KERNEL);
+	b = kzalloc(COMMAND_PACKET_SIZE + 4, GFP_KERNEL);
 	if (!b)
 		return -ENOMEM;
 


### PR DESCRIPTION
Hi again,

I identified another potential vulnerability in clone functions in `drivers/media/usb/ttusb-dec/ttusb_dec.c` sourced from [torvalds/linux](https://github.com/torvalds/linux). This issue, originally reported in [CVE-2019-19533](https://nvd.nist.gov/vuln/detail/cve-2019-19533), was resolved in the repository via this commit https://github.com/torvalds/linux/commit/a10feaf8c464c3f9cfdd3a8a7ce17e1c0d498da1.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you!