### PR TITLE
Fix potential vulnerability in a cloned function

### DIFF
--- a/drivers/vhost/net.c
+++ b/drivers/vhost/net.c
@@ -838,10 +838,6 @@ static int vhost_net_release(struct inode *inode, struct file *f)
 
 static struct socket *get_raw_socket(int fd)
 {
-	struct {
-		struct sockaddr_ll sa;
-		char  buf[MAX_ADDR_LEN];
-	} uaddr;
 	int uaddr_len = sizeof uaddr, r;
 	struct socket *sock = sockfd_lookup(fd, &r);
 
@@ -854,12 +850,7 @@ static struct socket *get_raw_socket(int fd)
 		goto err;
 	}
 
-	r = sock->ops->getname(sock, (struct sockaddr *)&uaddr.sa,
-			       &uaddr_len, 0);
-	if (r)
-		goto err;
-
-	if (uaddr.sa.sll_family != AF_PACKET) {
+	if (sock->sk->sk_family != AF_PACKET) {
 		r = -EPFNOSUPPORT;
 		goto err;
 	}


### PR DESCRIPTION
Hi again,

I identified another potential vulnerability in clone functions in `drivers/vhost/net.c` sourced from [torvalds/linux](https://github.com/torvalds/linux). This issue, originally reported in [CVE-2020-10942](https://nvd.nist.gov/vuln/detail/cve-2020-10942), was resolved in the repository via this commit https://github.com/torvalds/linux/commit/42d84c8490f9f0931786f1623191fcab397c3d64.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you!